### PR TITLE
Coalesce

### DIFF
--- a/autoinstall-generator/convert.py
+++ b/autoinstall-generator/convert.py
@@ -71,13 +71,13 @@ def netmask(value, line):
 
 
 def mirror_http_hostname(value, line):
-    directive = Directive('', line, ConversionType.Dependent)
+    directive = Directive({}, line, ConversionType.Dependent)
     directive.fragments = {'mirror/http': {'hostname': value}}
     return directive
 
 
 def mirror_http_directory(value, line):
-    directive = Directive('', line, ConversionType.Dependent)
+    directive = Directive({}, line, ConversionType.Dependent)
     directive.fragments = {'mirror/http': {'directory': value}}
     return directive
 

--- a/autoinstall-generator/convert.py
+++ b/autoinstall-generator/convert.py
@@ -1,8 +1,6 @@
 
 import copy
 from enum import Enum
-from merging import merge
-import yaml
 
 
 class ConversionType(Enum):
@@ -13,8 +11,11 @@ class ConversionType(Enum):
     # a single d-i directive that has a 1:1 mapping with an autoinstall
     OneToOne = 2,
     # a d-i directive that, when paired with matching Dependent
-    # direcitves, can output autoinstall directive(s)
+    # directives, can output autoinstall directive(s)
     Dependent = 3,
+    # the result of two or more Dependent directives being grouped into
+    # a single, resolved, directive
+    Coallesced = 4,
 
 
 class Directive:
@@ -35,12 +36,16 @@ class Directive:
         partial data derived from Dependent preseed directives that,
         when coallased with all other Dependent directives, will yield a
         useable output
+    children : list of Directive
+        a list of child Directive objects that were the source of this
+        Directive
     '''
     def __init__(self, tree, orig_input, convert_type):
         self.tree = tree
         self.orig_input = orig_input
         self.convert_type = convert_type
         self.fragments = {}
+        self.children = []
 
 
 def netmask_bits(value):
@@ -158,19 +163,3 @@ def insert_at_none(tree, value):
         elif cur is None:
             tree[key] = value
     return tree
-
-
-def convert_file(filepath):
-    directives = []
-
-    with open(filepath, 'r') as preseed_file:
-        for line in preseed_file.readlines():
-            directive = convert(line)
-            if directive.convert_type == ConversionType.OneToOne:
-                directives.append(directive)
-
-    result_dict = merge(directives)
-
-    result = yaml.dump(result_dict, default_flow_style=False)
-
-    return result

--- a/autoinstall-generator/convert.py
+++ b/autoinstall-generator/convert.py
@@ -15,7 +15,7 @@ class ConversionType(Enum):
     Dependent = 3,
     # the result of two or more Dependent directives being grouped into
     # a single, resolved, directive
-    Coallesced = 4,
+    Coalesced = 4,
 
 
 class Directive:

--- a/autoinstall-generator/merging.py
+++ b/autoinstall-generator/merging.py
@@ -1,4 +1,8 @@
 
+from convert import convert, Directive, ConversionType
+import yaml
+
+
 def do_merge(a, b):
     '''Take a pair of dictionaries, and provide the merged result.
        Assumes that any key conflicts have values that are themselves
@@ -24,5 +28,29 @@ def merge(directives):
     result = {}
     for d in directives:
         result = do_merge(result, d.tree)
+
+    return result
+
+
+def coallesce(directives):
+    '''Take a list of co-dependent directives, and output a coallesced
+       Directive that represents resolution of all the dependent values.'''
+    result = Directive({}, '', ConversionType.Coallesced)
+    result.children = directives
+    return result
+
+
+def convert_file(filepath):
+    directives = []
+
+    with open(filepath, 'r') as preseed_file:
+        for line in preseed_file.readlines():
+            directive = convert(line)
+            if directive.convert_type == ConversionType.OneToOne:
+                directives.append(directive)
+
+    result_dict = merge(directives)
+
+    result = yaml.dump(result_dict, default_flow_style=False)
 
     return result

--- a/autoinstall-generator/merging.py
+++ b/autoinstall-generator/merging.py
@@ -33,10 +33,10 @@ def merge(directives):
     return result
 
 
-def coallesce(directives):
-    '''Take a list of co-dependent directives, and output a coallesced
+def coalesce(directives):
+    '''Take a list of co-dependent directives, and output a coalesced
        Directive that represents resolution of all the dependent values.'''
-    result = Directive({}, '', ConversionType.Coallesced)
+    result = Directive({}, '', ConversionType.Coalesced)
     result.children = directives
 
     result.fragments = {}
@@ -63,11 +63,11 @@ class Bucket:
     def __init__(self):
         self.independent = []
         self.dependent = {}
-    def coallesce(self):
+    def coalesce(self):
         result = copy.copy(self.independent)
         for key in self.dependent:
             cur = self.dependent[key]
-            result.append(coallesce(cur))
+            result.append(coalesce(cur))
         return result
 
 

--- a/autoinstall-generator/merging.py
+++ b/autoinstall-generator/merging.py
@@ -37,6 +37,24 @@ def coallesce(directives):
        Directive that represents resolution of all the dependent values.'''
     result = Directive({}, '', ConversionType.Coallesced)
     result.children = directives
+
+    result.fragments = {}
+    for d in directives:
+        result.fragments = do_merge(result.fragments, d.fragments)
+
+    hostname = result.fragments['mirror/http']['hostname']
+    directory = result.fragments['mirror/http']['directory']
+    result.tree = {
+        'apt': {
+            'primary': [
+                {
+                    'arches': ['default'],
+                    'uri': f'http://{hostname}{directory}'
+                }
+            ]
+        }
+    }
+
     return result
 
 

--- a/autoinstall-generator/tests/test_basic.py
+++ b/autoinstall-generator/tests/test_basic.py
@@ -24,9 +24,9 @@ def full_flow(start, expected, convert_type):
         directives.append(cur)
 
     buckets = bucketize(directives)
-    coallesced = buckets.coallesce()
+    coalesced = buckets.coalesce()
 
-    assert expected == merge(coallesced)
+    assert expected == merge(coalesced)
 
 
 def one_to_one(start, expected):

--- a/autoinstall-generator/tests/test_basic.py
+++ b/autoinstall-generator/tests/test_basic.py
@@ -19,6 +19,7 @@ def trivial(start, expected, convert_type):
     for item in start:
         cur = convert(item)
         assert convert_type == cur.convert_type
+        assert dict == type(cur.tree)
         directives.append(cur)
 
     assert expected == merge(directives)

--- a/autoinstall-generator/tests/test_basic.py
+++ b/autoinstall-generator/tests/test_basic.py
@@ -1,8 +1,9 @@
 
 from convert import (convert, Directive, ConversionType, netmask_bits,
                      insert_at_none)
-from merging import merge
-import pytest
+from merging import merge, bucketize
+# import pytest
+# @pytest.mark.skip('pending dependent fragments')
 
 
 # FIXME actually generate files
@@ -10,7 +11,7 @@ import pytest
 # FIXME dependency support - to handle ipaddress / netmask
 
 
-def trivial(start, expected, convert_type):
+def full_flow(start, expected, convert_type):
     directives = []
 
     if type(start) == str:
@@ -22,15 +23,18 @@ def trivial(start, expected, convert_type):
         assert dict == type(cur.tree)
         directives.append(cur)
 
-    assert expected == merge(directives)
+    buckets = bucketize(directives)
+    coallesced = buckets.coallesce()
+
+    assert expected == merge(coallesced)
 
 
 def one_to_one(start, expected):
-    trivial(start, expected, ConversionType.OneToOne)
+    full_flow(start, expected, ConversionType.OneToOne)
 
 
 def dependent(start, expected):
-    trivial(start, expected, ConversionType.Dependent)
+    full_flow(start, expected, ConversionType.Dependent)
 
 
 def test_directive():
@@ -161,7 +165,6 @@ def test_di_nameservers():
                 'nameservers': {'addresses': [value]}}}}})
 
 
-@pytest.mark.skip('pending dependent fragments')
 def test_di_mirror():
     # d-i mirror/http/hostname string http.us.debian.org
     # d-i mirror/http/directory string /debian

--- a/autoinstall-generator/tests/test_merge.py
+++ b/autoinstall-generator/tests/test_merge.py
@@ -1,6 +1,6 @@
 
 from convert import Directive, ConversionType
-from merging import merge, do_merge
+from merging import merge, do_merge, coallesce
 import pytest
 
 
@@ -74,3 +74,21 @@ def test_list():
 
     actual = merge([a, b, c])
     assert expected == actual
+
+
+def test_coallesce():
+    hostname = Directive({}, '', ConversionType.Dependent)
+    directory = Directive({}, '', ConversionType.Dependent)
+    hostname.fragments = {'mirror/http': {'hostname': 'asdf'}}
+    directory.fragments = {'mirror/http': {'directory': '/qwerty'}}
+
+    directives = [hostname, directory]
+
+    actual = coallesce(directives)
+    # expected_tree = {'apt': {
+    #                     'primary': [{
+    #                         'arches': ['default'],
+    #                         'uri': f'http://asdf/qwerty'}]}}
+    assert ConversionType.Coallesced == actual.convert_type
+    assert directives == actual.children
+    # assert expected_tree == actual.tree

--- a/autoinstall-generator/tests/test_merge.py
+++ b/autoinstall-generator/tests/test_merge.py
@@ -85,10 +85,17 @@ def test_coallesce():
     directives = [hostname, directory]
 
     actual = coallesce(directives)
-    # expected_tree = {'apt': {
-    #                     'primary': [{
-    #                         'arches': ['default'],
-    #                         'uri': f'http://asdf/qwerty'}]}}
+    expected_tree = {'apt': {
+                        'primary': [{
+                            'arches': ['default'],
+                            'uri': f'http://asdf/qwerty'}]}}
+    expected_fragments = {
+        'mirror/http': {
+            'hostname': 'asdf',
+            'directory': '/qwerty',
+        }
+    }
     assert ConversionType.Coallesced == actual.convert_type
     assert directives == actual.children
-    # assert expected_tree == actual.tree
+    assert expected_fragments == actual.fragments
+    assert expected_tree == actual.tree

--- a/autoinstall-generator/tests/test_merge.py
+++ b/autoinstall-generator/tests/test_merge.py
@@ -1,6 +1,6 @@
 
 from convert import convert, Directive, ConversionType
-from merging import merge, do_merge, coallesce, bucketize, Bucket
+from merging import merge, do_merge, coalesce, bucketize, Bucket
 import pytest
 
 
@@ -76,7 +76,7 @@ def test_list():
     assert expected == actual
 
 
-def test_coallesce():
+def test_coalesce():
     hostname = 'asdf'
     directory = '/qwerty'
     lines = [
@@ -88,7 +88,7 @@ def test_coallesce():
     for line in lines:
         directives.append(convert(line))
 
-    actual = coallesce(directives)
+    actual = coalesce(directives)
     expected_tree = {
         'apt': {
             'primary': [{
@@ -103,7 +103,7 @@ def test_coallesce():
             'directory': directory,
         }
     }
-    assert ConversionType.Coallesced == actual.convert_type
+    assert ConversionType.Coalesced == actual.convert_type
     assert directives == actual.children
     assert expected_fragments == actual.fragments
     assert expected_tree == actual.tree
@@ -111,7 +111,7 @@ def test_coallesce():
 
 def test_bucketize():
     # bucketization is the process by which directives are processed to
-    # determine if they are standalone or if they require coallescing.
+    # determine if they are standalone or if they require coalescing.
     lines = [
         'd-i mirror/http/hostname string a',
         'd-i mirror/http/directory string /b',
@@ -129,7 +129,7 @@ def test_bucketize():
     for d in buckets.dependent[key]:
         assert ConversionType.Dependent == d.convert_type
 
-def test_coallesce_buckets():
+def test_coalesce_buckets():
     buckets = Bucket()
     lines = [
         'd-i mirror/http/hostname string a',
@@ -139,7 +139,7 @@ def test_coallesce_buckets():
     directives = [convert(l) for l in lines]
     buckets.dependent[key] = directives
 
-    coallesced = buckets.coallesce()
+    coalesced = buckets.coalesce()
 
-    assert 1 == len(coallesced)
-    assert ConversionType.Dependent != coallesced[0].convert_type
+    assert 1 == len(coalesced)
+    assert ConversionType.Dependent != coalesced[0].convert_type

--- a/autoinstall-generator/tests/test_reader.py
+++ b/autoinstall-generator/tests/test_reader.py
@@ -1,5 +1,6 @@
 
-from convert import (convert, ConversionType, convert_file)
+from convert import convert, ConversionType
+from merging import convert_file
 
 
 expected_lines = '''\

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
     pytest
     pytest-cov
     pyyaml
-commands = pytest --cov autoinstall-generator
+commands = pytest --cov autoinstall-generator --cov-report term-missing


### PR DESCRIPTION
Identify (the first case of) directives that are dependent on each other and                                                   
merge them thru a process called 'coallese'.  Dependent directives are                                                         
prefiltered into buckets based on their interdependent key, then subsequently                                                  
unified into a single directives that represents the merged state of all the                                                   
dependent directives on that key.  This single directive can then be                                                           
intermingled in a pool of OneToOne directives for subsequent output.                                                           