### PR TITLE
Tox: try using without the environment spec

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,4 +27,4 @@ jobs:
       run: pip install tox
     - name: Run Tox
       # Run tox using the version of Python in `PATH`
-      run: tox -e py
+      run: tox

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build:
 .PHONY: build
 
 test:
-	tox -e py
+	tox
 .PHONY: test
 
 check: test

--- a/autoinstall-generator/merging.py
+++ b/autoinstall-generator/merging.py
@@ -63,6 +63,7 @@ class Bucket:
     def __init__(self):
         self.independent = []
         self.dependent = {}
+
     def coalesce(self):
         result = copy.copy(self.independent)
         for key in self.dependent:

--- a/autoinstall-generator/tests/test_basic.py
+++ b/autoinstall-generator/tests/test_basic.py
@@ -20,7 +20,7 @@ def full_flow(start, expected, convert_type):
     for item in start:
         cur = convert(item)
         assert convert_type == cur.convert_type
-        assert dict == type(cur.tree)
+        assert isinstance(cur.tree, dict)
         directives.append(cur)
 
     buckets = bucketize(directives)

--- a/autoinstall-generator/tests/test_merge.py
+++ b/autoinstall-generator/tests/test_merge.py
@@ -119,7 +119,7 @@ def test_bucketize():
     ]
     key = 'mirror/http'
 
-    directives = [convert(l) for l in lines]
+    directives = [convert(line) for line in lines]
     buckets = bucketize(directives)
     assert 1 == len(buckets.independent)
     assert ConversionType.OneToOne == buckets.independent[0].convert_type
@@ -129,6 +129,7 @@ def test_bucketize():
     for d in buckets.dependent[key]:
         assert ConversionType.Dependent == d.convert_type
 
+
 def test_coalesce_buckets():
     buckets = Bucket()
     lines = [
@@ -136,7 +137,7 @@ def test_coalesce_buckets():
         'd-i mirror/http/directory string /b',
     ]
     key = 'mirror/http'
-    directives = [convert(l) for l in lines]
+    directives = [convert(line) for line in lines]
     buckets.dependent[key] = directives
 
     coalesced = buckets.coalesce()


### PR DESCRIPTION
Right now flake8 isn't acutally running.  Remove environment
specification to pursue this.  Will it pick up python from the
environment anyhow?