### PR TITLE
Proposal: Handle multiline directives

### DIFF
--- a/autoinstall_generator/merging.py
+++ b/autoinstall_generator/merging.py
@@ -202,8 +202,20 @@ def dump_yaml(tree):
 def convert_file(preseed_file, args):
     directives = implied_directives()
 
+    fullDirective = None
     for idx, line in enumerate(preseed_file.readlines()):
-        directives.append(convert(line.strip('\n'), idx + 1))
+        line = line.strip('\n')
+        cleanedLine = line.rstrip('\\').strip(' ')
+
+        if fullDirective is None:
+            fullDirective = cleanedLine
+            startIdx = idx
+        else:
+            fullDirective = ' '.join([fullDirective, cleanedLine])
+
+        if not line.endswith('\\'):
+            directives.append(convert(fullDirective, startIdx + 1))
+            fullDirective = None
 
     buckets = bucketize(directives)
     coalesced = buckets.coalesce()


### PR DESCRIPTION
Multiline directives (ie: directives split over lines using a '\\' on the end of each line) cause the generator to fail with a stacktrace.

For example, this will fail when the generator is run on it:

```
tasksel tasksel/first multiselect server
d-i pkgsel/include string \
    vim \
    rsync \
    wget \
    curl
```

Changes here will combine lines of the 'd-i pkgsel/include', stripping surrounding space, and joining them together with a single space.  The generator will run to completion with this changes for preseeds with multilines.  pkgsel/include is still unsupported, so with the above example, it still doesn't get converted, but at least it doesn't break the generator

idx is handled to use keep track fo the line the directive starts on, and to pass that on the `directives.append()` line.

Rather than no result and a stacktrace, with these change, the resulting generator output for the above example (run with -d here) looks like:

```
debconf-selections: tasksel tasksel/first multiselect server
version: 1
# 1:   Directive: tasksel tasksel/first multiselect server
#      Mapped to: {debconf-selections: tasksel tasksel/first multiselect server}
# 2: Unsupported: d-i pkgsel/include string vim rsync wget curl
```